### PR TITLE
Make FHIR connector async and clean tests

### DIFF
--- a/tests/test_fhir_connector.py
+++ b/tests/test_fhir_connector.py
@@ -53,7 +53,7 @@ def test_get_patient_with_mocked_http(monkeypatch):
 
     connector = FHIRConnector(server_url="http://fake.fhir")
 
-    def fake_get(url, params=None):
+    async def fake_get(url, params=None):
         # Simple routing by path
         if url.endswith(f"/Patient/{patient.get('id')}") or "/Patient/" in url:
             return FakeResponse(patient)
@@ -67,8 +67,11 @@ def test_get_patient_with_mocked_http(monkeypatch):
             return FakeResponse(enc_bundle)
         return FakeResponse({})
 
+    class FakeSession:
+        get = staticmethod(fake_get)
+
     # Patch the connector's session.get
-    monkeypatch.setattr(connector, "session", type("S", (), {"get": staticmethod(fake_get)})())
+    monkeypatch.setattr(connector, "session", FakeSession())
 
     # Call the async get_patient via asyncio.run
     result = asyncio.run(connector.get_patient(patient.get("id")))

--- a/tests/test_s_lora.py
+++ b/tests/test_s_lora.py
@@ -23,30 +23,3 @@ def test_activate_deactivate_adapter():
     # Deactivate
     ok2 = asyncio.run(mgr.deactivate_adapter(adapter))
     assert ok2 is True
-import asyncio
-from backend.s_lora_manager import SLoRAManager
-import asyncio
-from backend.s_lora_manager import SLoRAManager
-
-
-def test_initialize_adapters():
-    mgr = SLoRAManager(adapter_path="./models/adapters", base_model="meta-llama/Llama-2-7b-hf")
-    assert len(mgr.adapters) >= 5
-    assert "adapter_cardiology" in mgr.adapters.values().__str__() or "adapter_cardiology" in mgr.adapters
-
-
-def test_select_adapters_simple():
-    mgr = SLoRAManager(adapter_path="./models/adapters", base_model="meta-llama/Llama-2-7b-hf")
-    selected = asyncio.run(mgr.select_adapters(["cardiology"]))
-    assert isinstance(selected, list)
-    assert any("cardio" in a for a in selected)
-
-
-def test_activate_deactivate_adapter():
-    mgr = SLoRAManager(adapter_path="./models/adapters", base_model="meta-llama/Llama-2-7b-hf")
-    adapter = list(mgr.adapters.keys())[0]
-    ok = asyncio.run(mgr.activate_adapter(adapter))
-    assert ok is True
-    # Deactivate
-    ok2 = asyncio.run(mgr.deactivate_adapter(adapter))
-    assert ok2 is True


### PR DESCRIPTION
## Summary
- switch the FHIR connector to use httpx.AsyncClient with awaited network calls and async cleanup
- update FHIR connector tests to use async fake session responses
- remove duplicate S-LoRA test definitions to avoid shadowing

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307a0b46f4832d991261d35913ae88)