### PR TITLE
Use AsyncClient for FHIRConnector requests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -101,10 +101,11 @@ async def lifespan(app: FastAPI):
         raise
     
     yield
-    
+
     # Shutdown
     logger.info("Shutting down Healthcare AI Assistant...")
-    # Add cleanup code here if needed
+    if fhir_connector:
+        await fhir_connector.aclose()
     logger.info("Shutdown complete")
 
 


### PR DESCRIPTION
## Summary
- switch FHIRConnector to use httpx.AsyncClient and await all HTTP requests
- add async cleanup for the connector and invoke it during FastAPI shutdown
- update connector tests to use async fakes and avoid unclosed session warnings

## Testing
- pytest tests/test_fhir_connector.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307b3df6d8832d90b2bc9c6fbc138d)