### PR TITLE
Handle optional fhir.resources dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ docker-compose up -d
 
 ## 📚 Module Guide
 
+## Backend Components
+- The `FHIRConnector` validates incoming FHIR Patient resources using `fhir.resources` when available; if the optional dependency isn't installed, it transparently falls back to a no-op validator.
+- Configure the connector's `use_proxies` parameter to `False` in environments without SOCKS proxy support to avoid initialization warnings.
+
 ### Backend Modules
 
 #### `/backend/fhir_connector.py`

--- a/backend/fhir_connector.py
+++ b/backend/fhir_connector.py
@@ -10,7 +10,23 @@ import httpx
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 import json
-from fhir.resources.patient import Patient
+
+try:
+    from fhir.resources.patient import Patient
+except ImportError:  # Optional dependency for schema validation
+    class Patient:
+        """Fallback Patient model when fhir.resources is unavailable."""
+
+        @staticmethod
+        def model_validate(fhir_patient):
+            class _Validated:
+                def __init__(self, payload):
+                    self.payload = payload
+
+                def model_dump(self, mode=None):
+                    return self.payload
+
+            return _Validated(fhir_patient)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add a lightweight fallback Patient validator when fhir.resources is not installed
- document optional validation dependency and proxy guidance in the Backend Components README section

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx' in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b94ad19c832da594618fa3a4ebf7)