### PR TITLE
Add SMART-on-FHIR OAuth support

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -126,11 +126,19 @@ ollama pull llama2
 
 ### 2. Connect to FHIR Data Source
 
-Configure your EHR connection in `.env`:
+Configure your EHR connection in `.env` using SMART-on-FHIR credentials:
 
 ```env
 FHIR_SERVER_URL=https://your-hospital-fhir.com/fhir
-FHIR_API_KEY=your-api-key
+SMART_CLIENT_ID=your-smart-client-id
+SMART_CLIENT_SECRET=super-secret
+SMART_SCOPE="system/*.read patient/*.read user/*.read"
+# Optional overrides if discovery is not available
+# SMART_AUTH_URL=https://ehr-authorize.example.com
+# SMART_TOKEN_URL=https://ehr-token.example.com
+# SMART_WELL_KNOWN=https://your-hospital-fhir.com/fhir/.well-known/smart-configuration
+# SMART_AUDIENCE=https://your-hospital-fhir.com/fhir
+# SMART_REFRESH_TOKEN=provided-refresh-token
 ```
 
 Or use test FHIR server (included with docker-compose):

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -140,9 +140,15 @@ cp .env.example .env
 ```env
 # FHIR Server Configuration
 FHIR_SERVER_URL=https://fhir.example.com/fhir
-FHIR_API_KEY=your-fhir-api-key
-FHIR_USERNAME=username
-FHIR_PASSWORD=password
+SMART_CLIENT_ID=your-smart-client-id
+SMART_CLIENT_SECRET=your-smart-client-secret
+SMART_SCOPE="system/*.read patient/*.read user/*.read"
+# Optional SMART overrides
+# SMART_AUTH_URL=https://ehr-authorize.example.com
+# SMART_TOKEN_URL=https://ehr-token.example.com
+# SMART_WELL_KNOWN=https://fhir.example.com/fhir/.well-known/smart-configuration
+# SMART_AUDIENCE=https://fhir.example.com/fhir
+# SMART_REFRESH_TOKEN=provided-refresh-token
 
 # LLM Configuration
 LLM_MODEL=gpt-4

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -134,7 +134,14 @@ OPENAI_API_KEY=sk-...
 
 ### Optional
 ```env
-FHIR_API_KEY=your-key
+SMART_CLIENT_ID=your-smart-client-id
+SMART_CLIENT_SECRET=your-smart-client-secret
+SMART_SCOPE="system/*.read patient/*.read user/*.read"
+# SMART_AUTH_URL=https://ehr-authorize.example.com
+# SMART_TOKEN_URL=https://ehr-token.example.com
+# SMART_WELL_KNOWN=http://localhost:8080/fhir/.well-known/smart-configuration
+# SMART_AUDIENCE=http://localhost:8080/fhir
+# SMART_REFRESH_TOKEN=provided-refresh-token
 ANTHROPIC_API_KEY=sk-ant-...
 DEBUG=False
 LOG_LEVEL=INFO

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,16 @@ async def lifespan(app: FastAPI):
         logger.info("Loading FHIR Connector...")
         fhir_connector = FHIRConnector(
             server_url=os.getenv("FHIR_SERVER_URL", "http://localhost:8080/fhir"),
-            api_key=os.getenv("FHIR_API_KEY", "")
+            client_id=os.getenv("SMART_CLIENT_ID", ""),
+            client_secret=os.getenv("SMART_CLIENT_SECRET", ""),
+            scope=os.getenv(
+                "SMART_SCOPE", "system/*.read patient/*.read user/*.read"
+            ),
+            auth_url=os.getenv("SMART_AUTH_URL") or None,
+            token_url=os.getenv("SMART_TOKEN_URL") or None,
+            well_known_url=os.getenv("SMART_WELL_KNOWN") or None,
+            audience=os.getenv("SMART_AUDIENCE") or None,
+            refresh_token=os.getenv("SMART_REFRESH_TOKEN") or None,
         )
         
         logger.info("Loading LLM Engine...")

--- a/tests/test_fhir_connector.py
+++ b/tests/test_fhir_connector.py
@@ -6,8 +6,9 @@ from backend.fhir_connector import FHIRConnector
 
 
 class FakeResponse:
-    def __init__(self, data):
+    def __init__(self, data, status_code=200):
         self._data = data
+        self.status_code = status_code
 
     def json(self):
         return self._data
@@ -53,7 +54,7 @@ def test_get_patient_with_mocked_http(monkeypatch):
 
     connector = FHIRConnector(server_url="http://fake.fhir")
 
-    async def fake_get(url, params=None):
+    async def fake_get(url, params=None, headers=None):
         # Simple routing by path
         if url.endswith(f"/Patient/{patient.get('id')}") or "/Patient/" in url:
             return FakeResponse(patient)
@@ -68,7 +69,7 @@ def test_get_patient_with_mocked_http(monkeypatch):
         return FakeResponse({})
 
     class FakeSession:
-        get = staticmethod(fake_get)
+        request = staticmethod(lambda method, url, params=None, headers=None: fake_get(url, params=params, headers=headers))
 
     # Patch the connector's session.get
     monkeypatch.setattr(connector, "session", FakeSession())


### PR DESCRIPTION
## Summary
- replace API key/basic auth in the FHIR connector with SMART-on-FHIR OAuth, including discovery, token exchange, refresh, and scope enforcement
- update backend configuration to accept SMART client credentials and authorization/token endpoints
- document SMART environment variables and refresh connector tests for the new request flow

## Testing
- pytest tests/test_fhir_connector.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69310a583bc4832d93cbab3dba80cfdf)