### PR TITLE
Add branch status report

### DIFF
--- a/BRANCH_STATUS.md
+++ b/BRANCH_STATUS.md
@@ -1,0 +1,3 @@
+# Branch Status
+
+After reviewing the Git repository, only a single branch (`work`) exists locally and no remotes are configured. There are no unused or unimplemented branches to close at this time.


### PR DESCRIPTION
## Summary
- add a brief branch status report indicating only the `work` branch exists locally
- note that no remotes or extra branches are present to close

## Testing
- not run (not needed for documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f3a035e4832da4e7769fd474f01c)