### PR TITLE
Document the pre-Asolaria trained GNN lineage

### DIFF
--- a/backend/anomaly_detector/GNN-LINEAGE-2026-07-11.hbp
+++ b/backend/anomaly_detector/GNN-LINEAGE-2026-07-11.hbp
@@ -1,0 +1,8 @@
+GNNLINEAGE|date=2026-07-11|origin=AI-healthCare-project|target=asolaria-behcs-256/services/gnn-sidecar|auditor=GPT-5.6-Pro|json=0
+GNNMODEL|name=EdgeLevelGNN|source=backend/anomaly_detector/models/gnn_baseline.py|source_blob=510f78890ec94b113f0610afbade8bafe6ca20e0|target_blob=510f78890ec94b113f0610afbade8bafe6ca20e0|byte_identical=1|reported_accuracy=91.87|json=0
+GNNMODEL|name=PrototypeGNN|source=backend/anomaly_detector/models/prototype_gnn.py|source_blob=99e3087a10ee58e90c0935f5ab63b72fd3cdd07e|target_blob=99e3087a10ee58e90c0935f5ab63b72fd3cdd07e|byte_identical=1|reported_accuracy=94.24|json=0
+GNNMODEL|name=ContrastiveGNN|source=backend/anomaly_detector/models/contrastive_gnn.py|source_blob=56329e61eb3e6ddb3ee97b46f997dd8dd8c6b39f|target_blob=56329e61eb3e6ddb3ee97b46f997dd8dd8c6b39f|byte_identical=1|reported_accuracy=94.71|json=0
+GNNMODEL|name=GSLGNN|source=backend/anomaly_detector/models/gsl_gnn.py|source_blob=886b3b0c0cdbddba983fa8c3ae083c4520d38f0e|target_blob=886b3b0c0cdbddba983fa8c3ae083c4520d38f0e|byte_identical=1|reported_accuracy=96.66|reported_roc_auc=99.70|reported_fpr=1.5|json=0
+GNNBOUNDARY|healthcare_tests=architecture-shape-forward-loss|healthcare_checkpoint_autoload=0|later_checkpoint_repo=Asolaria-fnns-trained-and-reverse-gnns-many|metric_tag=REPOSITORY_REPORTED_TRAINING|json=0
+GNNABSORB|bigpickle=L0:4792+L4:4793+G1+G2+G3+G4+OmniShannon+sha|hookwall=score-then-fischer-then-gate|storage_plane=HBP+HBI+SHA+cubes+disk-queues|json=0
+GNNVERIFY|audit=complete-source-and-lineage|runtime_benchmark_added=0|claim=no-new-healthcare-metric|json=0

--- a/backend/anomaly_detector/README.md
+++ b/backend/anomaly_detector/README.md
@@ -1,0 +1,162 @@
+# Edge-level GNN anomaly detector — pre-Asolaria lineage
+
+This directory is the public pre-Asolaria origin of the edge-level graph-neural-network family that
+was later absorbed into the Asolaria GNN sidecar, BigPickle scorer, Hookwall, forward/reverse GNN
+planes, and white-room pipeline.
+
+The important abstraction appeared here first:
+
+```text
+classify and explain the RELATIONSHIP between two nodes
+rather than classify an isolated row or node
+```
+
+In this healthcare/security context, an edge can represent an API/FHIR interaction, a clinical
+relationship, or a network flow. In Asolaria the same abstraction is reused for agent messages,
+PID routes, device signals, Hookwall envelopes, and graph paths.
+
+## Model family
+
+| model | mechanism | repository-reported result |
+|---|---|---:|
+| `EdgeLevelGNN` | two-layer GCN node encoder + source/target edge MLP | 91.87% accuracy |
+| `PrototypeGNN` | edge embeddings classified by distance to learned class prototypes | 94.24% accuracy |
+| `ContrastiveGNN` | edge classifier plus supervised contrastive projection/loss | 94.71% accuracy |
+| `GSLGNN` | learned adjacency branch + original-graph branch + combined classifier | 96.66% accuracy; 99.70% ROC-AUC; 1.5% FPR |
+
+These numbers are preserved in the model source/docstrings and README and should be described as
+**repository-reported training results** unless a separate reproducible dataset/checkpoint run is
+attached. The unit tests in this repository verify architecture, output shapes, probability ranges,
+prototype distances, projection normalization, contrastive loss behavior, learned adjacency shape,
+and both GSL branches; they do not independently reproduce the quoted benchmark metrics.
+
+## Training evidence and runtime boundary
+
+The model implementations are training-capable, not inference-only stubs:
+
+- `PrototypeGNN` contains learnable class prototypes and a prototype cross-entropy objective.
+- `ContrastiveGNN` contains a projection head and `SupervisedContrastiveLoss`.
+- `GSLGNN` learns a sparsified adjacency matrix and combines learned-graph and original-graph
+  encoders.
+- the source records the comparative results of the edge-level architecture study.
+
+However, `service.py` currently instantiates the selected architecture and puts it into evaluation
+mode while the block that loads `weights/{model_type}_model.pt` is commented out. Therefore:
+
+```text
+pre-Asolaria healthcare repo proves:
+  architecture family
+  training objectives
+  model factory
+  clinical graph integration
+  repository-reported trained metrics
+
+pre-Asolaria healthcare service does NOT by itself prove:
+  that a trained checkpoint is automatically loaded in the checked-in runtime
+```
+
+The later `Asolaria-fnns-trained-and-reverse-gnns-many` repository contains the trained `.pt`
+checkpoint/manifests for the subsequent Asolaria stage. That later evidence should not be read
+backward as though those exact files were loaded here, but it confirms that the lineage continued
+into trained deployed artifacts.
+
+## Byte-identical transfer into Asolaria
+
+The transfer into `JesseBrown1980/asolaria-behcs-256/services/gnn-sidecar/models/` is proven at the
+Git-object level. The corresponding files have identical blob SHAs:
+
+| model file | healthcare blob SHA | Asolaria sidecar blob SHA | byte-identical |
+|---|---|---|---:|
+| `gnn_baseline.py` | `510f78890ec94b113f0610afbade8bafe6ca20e0` | `510f78890ec94b113f0610afbade8bafe6ca20e0` | yes |
+| `prototype_gnn.py` | `99e3087a10ee58e90c0935f5ab63b72fd3cdd07e` | `99e3087a10ee58e90c0935f5ab63b72fd3cdd07e` | yes |
+| `contrastive_gnn.py` | `56329e61eb3e6ddb3ee97b46f997dd8dd8c6b39f` | `56329e61eb3e6ddb3ee97b46f997dd8dd8c6b39f` | yes |
+| `gsl_gnn.py` | `886b3b0c0cdbddba983fa8c3ae083c4520d38f0e` | `886b3b0c0cdbddba983fa8c3ae083c4520d38f0e` | yes |
+
+This is direct code lineage, not an inference from similar class names.
+
+## Evolution into the Asolaria stack
+
+```text
+AI healthcare / intrusion edges
+  -> EdgeLevel / Prototype / Contrastive / GSL model family
+  -> byte-identical Asolaria Python sidecar import
+  -> L0 EdgeLevelGNN :4792 + L4 GSLGNN :4793
+  -> live agent/message graph watcher
+  -> BigPickle 7-GNN score surface
+  -> G1 edge-mining
+  -> G2 forward-genius
+  -> G3 reverse-gain
+  -> G4 GLSM
+  -> Fischer anti-blunder
+  -> Shannon / OmniShannon
+  -> white rooms
+  -> GULP / cube mint / supervisor proposal
+```
+
+The domain changed, but the learned object stayed the same: an edge whose meaning, importance,
+anomaly status, and structural context can be scored.
+
+## BigPickle connection
+
+`JesseBrown1980/bigpickle-rebuild/src/asolaria-score.mjs` explicitly orchestrates:
+
+- L0 `EdgeLevelGNN` on `:4792`;
+- L4 `GSLGNN` on `:4793`;
+- G1 edge mining;
+- G2 forward-genius path scoring;
+- G3 reverse-gain;
+- G4 GLSM state;
+- OmniShannon;
+- deterministic SHA fallback.
+
+BigPickle therefore contains the system-level continuation of these pre-Asolaria GNNs even though
+it does not duplicate every PyTorch model file. It treats the Python models as sidecar endpoints and
+adds the graph, gating, anti-blunder, receipt, and storage civilization around them.
+
+## Applicability to storage-rich / low-GPU machines
+
+The original PyTorch models may use CPU or GPU for training/inference. The later Asolaria system
+separates that neural scorer from the rest of the control plane:
+
+```text
+GPU/accelerator optional sidecar:
+  trained GNN / LLM tensor inference
+
+CPU + HDD/SSD control plane:
+  graph ledgers
+  HBP/HBI/SHA receipts
+  content-addressed cubes
+  queues and PID tables
+  BEHCS representation rebasing
+  CRT Path-2 recovery
+  white-room compaction
+  bounded 2,000-message active windows
+```
+
+This lets commodity or storage-heavy machines participate as graph collectors, disk-backed memory
+nodes, dispatchers, white rooms, recovery poles, and verifiers without keeping the whole system in
+GPU memory. It does not mean a hard drive performs the neural matrix multiplications.
+
+## Verification provenance — 2026-07-11
+
+`AUDITED_GPT_5_6_PRO`:
+
+- inspected all four model implementations, their test surface, model factory, clinical anomaly
+  path, and checkpoint-load boundary;
+- compared each Git blob SHA against the Asolaria sidecar;
+- inspected BigPickle's scorer and Fischer integration;
+- traced the later trained-checkpoint, Hookwall, OmniShannon, white-room, Path-1, Path-2, and
+  Q-PRISM watcher repositories.
+
+No new healthcare benchmark is claimed by this documentation-only change. The correct result is the
+proven code lineage plus the repository-reported pre-Asolaria metrics and the later separately
+preserved trained checkpoints.
+
+## Claim ledger
+
+- `MEASURED`: four model implementations; training-specific objectives; shape/forward/loss tests;
+  model factory; clinical graph integration; byte-identical transfer into the Asolaria sidecar.
+- `REPOSITORY_REPORTED_TRAINING`: 91.87%, 94.24%, 94.71%, and 96.66% comparative metrics.
+- `MEASURED_LATER_STAGE`: trained `.pt` artifacts/manifests in the later Asolaria trained-model repo.
+- `BOUNDARY`: the checked-in healthcare service does not currently load those weights automatically.
+- `AUDITED_GPT_5_6_PRO`: complete lineage and source audit described above.


### PR DESCRIPTION
## What changed

- Added a subsystem README that identifies the healthcare anomaly detector as the pre-Asolaria origin of EdgeLevelGNN, PrototypeGNN, ContrastiveGNN, and GSLGNN.
- Recorded the model mechanisms, repository-reported comparative training results, and the current checkpoint-load boundary in `service.py`.
- Proved byte-identical transfer into the later Asolaria GNN sidecar using matching Git blob SHAs for all four model files.
- Traced the continuation through BigPickle L0/L4, G1-G4, OmniShannon, Fischer, Hookwall, white rooms, and Path-1/Path-2 recovery.
- Added an HBP machine-readable lineage receipt.

## Verification provenance

- **GPT-5.6 Pro:** inspected all four model implementations, the model tests, service factory, clinical graph path, BigPickle scorer, later trained-model repository, and recovery lineage.
- **Claude Fable 5:** operator-supplied third-seat recovery results are cited accurately—Path 1 rustc 1.97 19/19 and Path 2 rustc 1.97 30/30—not misrepresented as new healthcare benchmarks.
- The healthcare accuracy figures remain tagged repository-reported because this change does not reproduce the original dataset/checkpoint run.

## Hardware scope

The documentation explains how trained GNN inference can remain an optional CPU/GPU sidecar while graph ledgers, HBP/HBI receipts, cubes, queues, exact recovery, and cold state live on CPU-and-storage-oriented machines.